### PR TITLE
Allowing the zip-code to be a string or a number

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -86,7 +86,7 @@
     - **account** - `string` *mandatory*, 21 characters.
     - **address** - `string` *mandatory*, max 70 characters.
     - **houseNumber** - `string | number` *optional*, max 16 characters.
-    - **zip** - `number` *mandatory*, max 16 characters.
+    - **zip** - `number | string` *mandatory*, max 16 characters.
     - **city** - `string` *mandatory*, max 35 characters.
     - **country** - `string` *mandatory*, 2 characters.
   - **debtor** *optional*
@@ -94,7 +94,7 @@
       > First name + last name or company name.
     - **address** - `string` *mandatory*, max 70 characters.
     - **houseNumber** - `string | number` *optional*, max 16 characters.
-    - **zip** - `number` *mandatory*, max 16 characters.
+    - **zip** - `number | string` *mandatory*, max 16 characters.
     - **city** - `string` *mandatory*, max 35 characters.
     - **country** - `string` *mandatory*, 2 characters.
 

--- a/src/swissqrbill.ts
+++ b/src/swissqrbill.ts
@@ -19,7 +19,7 @@ export interface data {
 export interface debtor {
   name: string,
   address: string,
-  zip: number,
+  zip: string | number,
   city: string,
   country: string
   houseNumber?: string | number

--- a/src/swissqrbill.ts
+++ b/src/swissqrbill.ts
@@ -677,7 +677,7 @@ export class PDF extends ExtendedPDF.PDF {
     //-- Creditor Zip
 
     if(this._data.creditor.zip === undefined){ throw new Error("Creditor zip cannot be undefined."); }
-    if(typeof this._data.creditor.zip !== "number"){ throw new Error("Creditor zip must be a number."); }
+    if(typeof this._data.creditor.zip !== "string" && typeof this._data.creditor.zip !== "number"){ throw new Error("Creditor zip must be either a string or a number."); }
     if(this._data.creditor.zip.toString().length > 16){ throw new Error("Creditor zip must be a maximum of 16 characters."); }
 
 
@@ -741,7 +741,7 @@ export class PDF extends ExtendedPDF.PDF {
       //-- Debtor zip
 
       if(this._data.debtor.zip === undefined){ throw new Error("Debtor zip cannot be undefined if the debtor object is available."); }
-      if(typeof this._data.debtor.zip !== "number"){ throw new Error("Debtor zip must be a number."); }
+      if(typeof this._data.debtor.zip !== "string" && typeof this._data.debtor.zip !== "number"){ throw new Error("Debtor zip must be either a string or a number."); }
       if(this._data.debtor.zip.toString().length > 16){ throw new Error("Debtor zip must be a maximum of 16 characters."); }
 
 

--- a/tests/run-windows.bat
+++ b/tests/run-windows.bat
@@ -57,3 +57,5 @@ echo "event"
   call node event
 echo "stream"
   call node stream
+echo "zip-string"
+call node zip-string

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -61,3 +61,5 @@ echo "event"
   node event
 echo "stream"
   node stream
+echo "zip-string"
+  node zip-string

--- a/tests/zip-string.js
+++ b/tests/zip-string.js
@@ -1,0 +1,23 @@
+const SwissQRBill = require("../lib/node");
+
+const data = {
+  currency: "CHF",
+  reference: "210000000003139471430009017",
+  creditor: {
+    name: "Robert Schneider AG",
+    address: "Rue du Lac 1268",
+    zip: "9104 BR",
+    city: "DAMWÂLD",
+    account: "CH4431999123000889012",
+    country: "NL"
+  },
+  debtor: {
+    name: "Pia-Maria Rutschmann-Schnyder",
+    address: "Grosse Marktgasse 28",
+    zip: "9104 BR",
+    city: "DAMWÂLD",
+    country: "NL"
+  }
+};
+
+const pdf = new SwissQRBill.PDF(data, "./output/zip-string.pdf");


### PR DESCRIPTION
Hi!

Certain countries, like the netherlands and the UK, have alphanumeric zip codes. I would thus suggest to allow for the zip-code to not only be a number, but also a string. 
I've updated the documentation, code and added a test in the PR.

