### PR TITLE
Remove unwanted first space with formatAmount()

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -183,7 +183,7 @@ export function formatSCORReference(reference: string): string {
  */
 export function formatAmount(amount: number): string {
 
-  const amountString = amount.toFixed(2) + "";
+  const amountString = amount.toFixed(2);
   const amountArray = amountString.split(".");
 
   let formattedAmountWithoutDecimals = "";
@@ -196,7 +196,7 @@ export function formatAmount(amount: number): string {
     }
   }
 
-  return formattedAmountWithoutDecimals + "." + amountArray[1];
+  return formattedAmountWithoutDecimals.trim() + "." + amountArray[1];
 
 }
 


### PR DESCRIPTION
`utils.formatAmount()` could return a first char which is not wanted.

```ts
utils.formatAmount(100) // return ' 100.00' (the first char is a space) as it should return '100.00'
```