### PR TITLE
[SVG] Fix formatting of reference in svg

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -49,7 +49,8 @@
     - [isQRReference(reference)](#isqrreferencereference)
     - [isQRReferenceValid(reference)](#isqrreferencereference)
     - [calculateQRReferenceChecksum(reference)](#calculateqrreferencechecksumreference)
-    - [formatQRReference(reference)](#formatQRReferencereference)
+    - [formatReference(reference)](#formatreferencereference)
+    - [formatQRReference(reference)](#formatqrreferencereference)
     - [formatSCORReference(reference)](#formatscorreferencereference)
   - Amount
     - [formatAmount(amount)](#formatamountamount)
@@ -410,6 +411,14 @@ Returns a `boolean`: true if the given reference is valid and false otherwise.
  - reference - `string` containing the 26 digits long reference (without the checksum) whose checksum should be calculated.
 Calculates the checksum according the specifications.
 Returns a `string` containing the calculated checksum.
+
+<br/>
+<br/>
+
+### formatReference(reference)
+ - reference - `string` containing the reference to be formatted.
+Detects the type of the given reference and formats it according the specifications to be easily readable.
+Returns a `string` containing the formatted reference.
 
 <br/>
 <br/>

--- a/src/pdf/pdf.ts
+++ b/src/pdf/pdf.ts
@@ -240,8 +240,9 @@ export class PDF_ extends ExtendedPDF {
 
       this.fontSize(8);
       this.font("Helvetica");
-      this.text(this._formatReference(this._data.reference), {
-        width: utils.mm2pt(52)
+      this.text(utils.formatReference(this._data.reference), {
+        width: utils.mm2pt(52),
+        lineGap: -.5
       });
 
     }
@@ -419,8 +420,9 @@ export class PDF_ extends ExtendedPDF {
 
       this.fontSize(10);
       this.font("Helvetica");
-      this.text(this._formatReference(this._data.reference), {
-        width: utils.mm2pt(87)
+      this.text(utils.formatReference(this._data.reference), {
+        width: utils.mm2pt(87),
+        lineGap: -.75
       });
 
       this.moveDown();
@@ -547,21 +549,6 @@ export class PDF_ extends ExtendedPDF {
     } else {
       return `${data.name}\n${data.address}\n${data.zip} ${data.city}`;
     }
-  }
-
-
-  private _formatReference(reference: string): string {
-
-    const referenceType = utils.getReferenceType(reference);
-
-    if(referenceType === "QRR"){
-      return utils.formatQRReference(reference);
-    } else if(referenceType === "SCOR"){
-      return utils.formatSCORReference(reference);
-    }
-
-    return reference;
-
   }
 
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -154,6 +154,27 @@ export function formatQRReference(reference: string): string {
 
 
 /**
+ * Detects the type of the given reference and formats it according the specifications to be easily readable.
+ *
+ * @param reference - The reference to be formatted.
+ * @returns The formatted reference.
+ */
+export function formatReference(reference: string): string {
+
+  const referenceType = getReferenceType(reference);
+
+  if(referenceType === "QRR"){
+    return formatQRReference(reference);
+  } else if(referenceType === "SCOR"){
+    return formatSCORReference(reference);
+  }
+
+  return reference;
+
+}
+
+
+/**
  * Formats the given SCOR-Reference according the specifications to be easily readable.
  *
  * @param reference - The SCOR-Reference to be formatted.

--- a/src/svg/svg.ts
+++ b/src/svg/svg.ts
@@ -137,7 +137,7 @@ export class SVG_ {
         .fontWeight("bold")
         .fontSize("6pt");
 
-      receiptTextContainer.addTSpan(utils.formatIBAN(this._data.reference))
+      receiptTextContainer.addTSpan(utils.formatReference(this._data.reference))
         .x(0)
         .dy("9pt")
         .fontFamily("Arial")
@@ -393,7 +393,7 @@ export class SVG_ {
         .fontWeight("bold")
         .fontSize("8pt");
 
-      paymentPartRightTextContainer.addTSpan(utils.formatIBAN(this._data.reference))
+      paymentPartRightTextContainer.addTSpan(utils.formatReference(this._data.reference))
         .x(0)
         .dy("11pt")
         .fontFamily("Arial")


### PR DESCRIPTION
 - [x] Fixed the formatting of the reference
 - [x] Add `utils.formatReference(reference)` function  