### PR TITLE
Modify _data to be protected instead of private to allow extending SwissQRBill

### DIFF
--- a/src/pdf/pdf.ts
+++ b/src/pdf/pdf.ts
@@ -9,7 +9,7 @@ import generateQRCode from "../shared/qr-code.js";
 export class PDF_ extends ExtendedPDF {
 
   public size: Size = "A6/5";
-  private _data: Data;
+  protected _data: Data;
   private _scissors: boolean = true;
   private _separate: boolean = false;
   private _outlines: boolean = true;


### PR DESCRIPTION
Cool and well maintained package!

We would like to use SwissQRBill to print multi-page bills with multiple different QR-bills.
For that purpose we want to extend PDF_, this however is currently not possible because _data is private.
Would it be possible to make it protected instead?

Merci!