### PR TITLE
Performance improvement for QR rendering

### DIFF
--- a/src/pdf/pdf.ts
+++ b/src/pdf/pdf.ts
@@ -549,16 +549,11 @@ export class PDF_ extends ExtendedPDF {
 
   private _renderQRCode(): void {
 
-    const qrcode = generateQRCode(this._data, utils.mm2pt(46));
-
+    const qrcode = generateQRCode(this._data, "pdf", utils.mm2pt(67), this._marginTop + utils.mm2pt(17), utils.mm2pt(46));
 
     //-- Add QR Code
 
-    this.addPath(qrcode, utils.mm2pt(67), this._marginTop + utils.mm2pt(17))
-      .undash()
-      .fillColor("black")
-      .fill();
-
+    this.fillColor("black").addContent(qrcode).fill();
 
     //-- Add Swiss Cross
 

--- a/src/pdf/pdf.ts
+++ b/src/pdf/pdf.ts
@@ -553,7 +553,7 @@ export class PDF_ extends ExtendedPDF {
 
     //-- Add QR Code
 
-    this.fillColor("black").addContent(qrcode).fill();
+    this.addContent(qrcode).fillColor("black").fill();
 
     //-- Add Swiss Cross
 
@@ -561,6 +561,7 @@ export class PDF_ extends ExtendedPDF {
     const swissCross = "M8.3 4H11.6V15H8.3V4Z M4.4 7.9H15.4V11.2H4.4V7.9Z";
 
     this.addPath(swissCrossBackground, utils.mm2pt(86.5), this._marginTop + utils.mm2pt(36))
+      .undash()
       .fillColor("black")
       .lineWidth(1.42)
       .strokeColor("white")

--- a/src/shared/qr-code.ts
+++ b/src/shared/qr-code.ts
@@ -2,7 +2,11 @@ import { getReferenceType } from "../shared/utils.js";
 import { Data } from "./types";
 import { qrcodegen } from "./qr-code-generator.js";
 
-function number(n: number) {
+/**
+ * Limits the maximum and minimum number possible according to the PDF specifications.
+ * Borrowed from: https://github.com/foliojs/pdfkit/blob/120c3f9519e49d719a88d22d70139cc9f54d17d8/lib/object.js#L123-L130
+ */
+function limitNumber(n: number) {
   if(n > -1e21 && n < 1e21){
     return Math.round(n * 1e6) / 1e6;
   }
@@ -249,7 +253,7 @@ export default function generateQRCode(data: Data, type: "pdf" | "svg", xOrigin:
 
         switch (type){
           case "pdf":
-            parts.push(`${number(xOrigin + xPos)} ${number(yOrigin + yPos)} ${number(blockSize)} ${number(blockSize)} re`);
+            parts.push(`${limitNumber(xOrigin + xPos)} ${limitNumber(yOrigin + yPos)} ${limitNumber(blockSize)} ${limitNumber(blockSize)} re`);
             break;
 
           case "svg":

--- a/src/shared/qr-code.ts
+++ b/src/shared/qr-code.ts
@@ -2,7 +2,15 @@ import { getReferenceType } from "../shared/utils.js";
 import { Data } from "./types";
 import { qrcodegen } from "./qr-code-generator.js";
 
-export default function generateQRCode(data: Data, size: number): string {
+function number(n: number) {
+  if(n > -1e21 && n < 1e21){
+    return Math.round(n * 1e6) / 1e6;
+  }
+
+  throw new Error(`unsupported number: ${n}`);
+}
+
+export default function generateQRCode(data: Data, type: "pdf" | "svg", xOrigin: number, yOrigin: number, size: number): string {
 
   let qrString = "";
 
@@ -238,7 +246,17 @@ export default function generateQRCode(data: Data, size: number): string {
     for(let y = 0; y < qrCode.size; y++){
       const yPos = y * blockSize;
       if(qrCode.getModule(x, y)){
-        parts.push(`M ${xPos}, ${yPos} V ${yPos + blockSize} H ${xPos + blockSize} V ${yPos} H ${xPos} Z `);
+
+        switch (type){
+          case "pdf":
+            parts.push(`${number(xOrigin + xPos)} ${number(yOrigin + yPos)} ${number(blockSize)} ${number(blockSize)} re`);
+            break;
+
+          case "svg":
+            parts.push(`M ${xPos}, ${yPos} V ${yPos + blockSize} H ${xPos + blockSize} V ${yPos} H ${xPos} Z `);
+            break;
+        }
+
       }
     }
 

--- a/src/svg/svg.ts
+++ b/src/svg/svg.ts
@@ -542,7 +542,7 @@ export class SVG_ {
 
   private _renderQRCode() {
 
-    const qrcode = generateQRCode(this._data, utils.mm2px(46));
+    const qrcode = generateQRCode(this._data, "svg", 0, 0, utils.mm2px(46));
 
     const qrcodeSVG = this.instance.addSVG("46mm", "46mm")
       .y("17mm")


### PR DESCRIPTION
It takes a lot of time to render a lot of QR Bills since addPath is an expensive function as we need to convert from QR segments to SVG and then to PDF.

We can bypass the conversion from QR to SVG, and directly convert QR segments to PDF.

This leads to huge performance benefits (a4.js):
| Number of bills | 10        | 100       | 1000    | 10000           |
|-----------------|-----------|-----------|---------|-----------------|
| Normal          | 754.651ms | 5.426s    | 50.278s | Node crashed :( |
| Modified        | 278.702ms | 969.642ms | 6.985s  | 1 min 7.421s    |


