### PR TITLE
test: fix visual tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,11 @@
 {
   "configurations": [
     {
-      "args": ["run", "${relativeFileDirname}/${fileBasenameNoExtension}"],
+      "args": [
+        "run",
+        "${relativeFileDirname}/${fileBasenameNoExtension}",
+        "--no-threads"
+      ],
       "autoAttachChildProcesses": true,
       "console": "integratedTerminal",
       "name": "debug current test file",
@@ -12,7 +16,11 @@
       "type": "node"
     },
     {
-      "args": ["run", "${relativeFileDirname}/${fileBasenameNoExtension}"],
+      "args": [
+        "run",
+        "${relativeFileDirname}/${fileBasenameNoExtension}",
+        "--no-threads"
+      ],
       "autoAttachChildProcesses": true,
       "console": "integratedTerminal",
       "env": {
@@ -26,7 +34,11 @@
       "type": "node"
     },
     {
-      "args": ["run", "${relativeFileDirname}/${fileBasenameNoExtension}"],
+      "args": [
+        "run",
+        "${relativeFileDirname}/${fileBasenameNoExtension}",
+        "--no-threads"
+      ],
       "autoAttachChildProcesses": true,
       "console": "integratedTerminal",
       "name": "debug current test file with node internals",

--- a/tests/utils/pdf.ts
+++ b/tests/utils/pdf.ts
@@ -24,7 +24,7 @@ export class TestDocument extends PDFDocument {
   constructor(testDocumentName: TestDocumentName, options?: PDFKit.PDFDocumentOptions) {
     super({ ...options, bufferPages: true, compress: false });
     this.testDocumentName = testDocumentName;
-    this.info.CreationDate = undefined;
+    this.info.CreationDate = new Date(0);
   }
 
   public async writeFile() {


### PR DESCRIPTION
- fixes invalid `CreationDate` breaking visual tests
- disables multi threading for a better call stack history while debugging